### PR TITLE
Fix wrong order of passed positional arguments with keyword arguments.

### DIFF
--- a/src/cellcharter/gr/_nhood.py
+++ b/src/cellcharter/gr/_nhood.py
@@ -307,12 +307,12 @@ def _diff_nhood_enrichment(
                     for samples_condition1_permuted in sample_perm_generator:
                         condition_permuted = pd.Categorical(libraries.isin(samples_condition1_permuted).astype(int))
                         expected_diff_enrichment = _diff_nhood_enrichment(
-                            labels=labels, 
-                            conditions=condition_permuted, 
-                            condition_groups=[0, 1], 
-                            libraries=libraries, 
-                            connectivities=connectivities, 
-                            pvalues=False, 
+                            labels=labels,
+                            conditions=condition_permuted,
+                            condition_groups=[0, 1],
+                            libraries=libraries,
+                            connectivities=connectivities,
+                            pvalues=False,
                             **nhood_kwargs,
                         )["0_1"]["enrichment"]
 

--- a/src/cellcharter/gr/_nhood.py
+++ b/src/cellcharter/gr/_nhood.py
@@ -307,7 +307,13 @@ def _diff_nhood_enrichment(
                     for samples_condition1_permuted in sample_perm_generator:
                         condition_permuted = pd.Categorical(libraries.isin(samples_condition1_permuted).astype(int))
                         expected_diff_enrichment = _diff_nhood_enrichment(
-                            labels, condition_permuted, [0, 1], libraries, connectivities, pvalues=False, **nhood_kwargs
+                            labels=labels, 
+                            conditions=condition_permuted, 
+                            condition_groups=[0, 1], 
+                            libraries=libraries, 
+                            connectivities=connectivities, 
+                            pvalues=False, 
+                            **nhood_kwargs,
                         )["0_1"]["enrichment"]
 
                         counts_pos = (


### PR DESCRIPTION
Originally: 
```
_diff_nhood_enrichment(
    labels,                 # labels
    condition_permuted,     # conditions
    [0, 1],                 # condition_groups
    libraries,              # should be connectivities, but this is libraries
    connectivities,         # should be pvalues, but this is connectivities
    pvalues=False,          # pvalues again
    **nhood_kwargs
)
```
got TypeError: _diff_nhood_enrichment() got multiple values for argument 'pvalues'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code readability in the differential neighborhood enrichment analysis routine through formatting adjustments to internal function calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->